### PR TITLE
fix: Specify corejs version to supress webpack warning

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -10,6 +10,7 @@ const presets = [
 				safari: '11.1',
 			},
 			useBuiltIns: 'usage',
+			corejs: 2,
 		},
 	],
 ];


### PR DESCRIPTION
Links:

https://github.com/babel/babel/issues/9751
https://github.com/vuejs/vuepress/issues/1471