### PR TITLE
fix: typos in README.md file:

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Fully customizable React boilerplate, using latest `React`, `webpack` and `babel
 
 - `git clone https://github.com/lakhansamani/react-minimal-boilerplate.git`
 - [Optional] `mv react-minimal-boilerplate PROJECT_NAME`
-- `cd react-minial-boilerplate` or `cd PROJECT_NAME`
+- `cd react-minimal-boilerplate` or `cd PROJECT_NAME`
 
 ### Development
 
@@ -20,7 +20,7 @@ Fully customizable React boilerplate, using latest `React`, `webpack` and `babel
 ### Testing
 
 - `yarn test`
-- If you change content of `src/App.js` then you might have to change the test in `src/App.test.js`. Also similary you can add test for more components.
+- If you change content of `src/App.js` then you might have to change the test in `src/App.test.js`. Also similarly you can add test for more components.
 
 ### How to add env variables to the application
 


### PR DESCRIPTION
Fixed two typos I found in README:
- 'minial' -> 'minimal'
- 'similary' -> 'similarly'