### PR TITLE
fix: hashes and add manifest for better caching

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,9 +17,7 @@ const isDevelopment = NODE_ENV === 'development';
 const plugins = [
   // Ignore all locale files of moment.js
   new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
-  new CleanWebpackPlugin({
-    cleanOnceBeforeBuildPatterns: ['dist/app'],
-  }),
+  new CleanWebpackPlugin(),
   new HtmlWebpackPlugin({
     template: './public/index.html',
     alwaysWriteToDisk: true,
@@ -31,10 +29,10 @@ const plugins = [
   new WriteWebPackPlugin(),
   new Dotenv(),
   new MiniCssExtractPlugin({
-    filename: isDevelopment ? '[name].css' : '[name].[chunkhash:8].css',
+    filename: isDevelopment ? '[name].css' : '[name].[contenthash:8].css',
     chunkFilename: isDevelopment
       ? '[name].bundle.css'
-      : '[name].[chunkhash:8].css',
+      : '[name].[contenthash:8].css',
   }),
 ];
 
@@ -44,12 +42,16 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, 'dist'),
     publicPath: '/',
-    filename: isDevelopment ? '[name].js' : '[name].[chunkhash:8].js',
+    filename: isDevelopment ? '[name].js' : '[name].[contenthash:8].js',
     chunkFilename: isDevelopment
       ? '[name].bundle.js'
-      : '[name].[chunkhash:8].js',
+      : '[name].[contenthash:8].js',
   },
   optimization: {
+    moduleIds: 'hashed',
+    runtimeChunk: {
+      name: 'manifest',
+    },
     minimizer: [new TerserJSPlugin({}), new OptimizeCSSAssetsPlugin({})],
     splitChunks: {
       cacheGroups: {


### PR DESCRIPTION
### Scenario

I added two components `A.js` & `B.js` and used in `App`. Usage: 


```
import React from 'react';
const A = React.lazy(() => import(/* webpackChunkName: "ModuleA" */ './A'));
const B = React.lazy(() => import(/* webpackChunkName: "ModuleB" */ './B'));

const App = () => (
  <div>
    <h1>Welcome to react app</h1>
    <React.Suspense>
      <A />
      <B />
    </React.Suspense>
  </div>
);

export default App;
```

### Testing Results

**With chunkhash**

https://gist.github.com/jyash97/c8356aa36408f052d4b0b46facd02ee7

**With contenthash and manifest**
https://gist.github.com/jyash97/dfe2936e91c9aa2f9e77a684d255bf53
